### PR TITLE
Fix: stop reporting info-level logs as Sentry issues (282-APP-ZN, ZP, Y8, V1, ZM)

### DIFF
--- a/lib/logging/sentry_logger.dart
+++ b/lib/logging/sentry_logger.dart
@@ -10,7 +10,17 @@ class SentryLogger implements Logger {
       if (context != null) debugPrint('CTX: $context');
       return;
     }
-    Sentry.captureMessage(message, level: SentryLevel.info);
+    // Info-level messages are expected, routine occurrences (e.g. deduped
+    // notifications) rather than problems. Recording them as breadcrumbs keeps
+    // them attached to any subsequent error's context without creating a
+    // standalone Sentry issue for every info log line.
+    Sentry.addBreadcrumb(
+      Breadcrumb(
+        message: message,
+        level: SentryLevel.info,
+        data: context,
+      ),
+    );
   }
 
   @override


### PR DESCRIPTION
## Problem
`Logger.info()` called `Sentry.captureMessage(message, level: SentryLevel.info)`, which creates a brand-new Sentry **issue** for every info-level log line — including routine, expected events like the navigation/overlay intent dedup logger (`Dropped duplicate intent: ...`). These were showing up as unresolved "errors" in Sentry even though nothing was actually wrong; the dedup logic was working exactly as intended.

This is the root cause of the following unresolved Sentry issues:
- https://alastair-mcneill.sentry.io/issues/282-APP-ZN
- https://alastair-mcneill.sentry.io/issues/282-APP-ZP
- https://alastair-mcneill.sentry.io/issues/282-APP-Y8
- https://alastair-mcneill.sentry.io/issues/282-APP-V1
- https://alastair-mcneill.sentry.io/issues/282-APP-ZM

## Fix
`lib/logging/sentry_logger.dart`: `info()` now calls `Sentry.addBreadcrumb(...)` instead of `Sentry.captureMessage(...)`. Info logs still get attached as breadcrumb context on any nearby real error, but they no longer create standalone issues.

`error()`/`fatal()` are unchanged — they still call `Sentry.captureException(...)` as before.

## Testing
No test harness available in this sandbox (no `flutter`/`dart` binary); change is a minimal, low-risk swap of one Sentry SDK call for another using the same imported package.

Fixes 282-APP-ZN, 282-APP-ZP, 282-APP-Y8, 282-APP-V1, 282-APP-ZM

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhNujrD8Yw4mgGdCVsw3zS)_