### PR TITLE
Fix: null check crash opening challenge detail with no achievement (282-APP-103)

### DIFF
--- a/lib/screens/munro_challenge/screens/munro_challenge_detail_screen.dart
+++ b/lib/screens/munro_challenge/screens/munro_challenge_detail_screen.dart
@@ -48,8 +48,8 @@ class MunroChallengeDetailScreen extends StatelessWidget {
     final munroCompletionState = context.watch<MunroCompletionState>();
     final munroState = context.watch<MunroState>();
 
-    final achievement = achievementsState.currentAchievement!;
-    final goal = achievement.annualTarget ?? 0;
+    final achievement = achievementsState.currentAchievement;
+    final goal = achievement?.annualTarget ?? 0;
 
     final yearCompletions = munroCompletionState.munroCompletions
         .where((mc) => mc.dateTimeCompleted.year == DateTime.now().year)


### PR DESCRIPTION
## Problem
`MunroChallengeDetailScreen.build` force-unwrapped `achievementsState.currentAchievement!`, but `currentAchievement` is nullable (e.g. before it's finished loading, or after being cleared on sign-out). Any build during that window crashed with `TypeError: Null check operator used on a null value` instead of falling back to the screen's existing "No challenge set" empty state, which is only reachable once `goal == 0` is evaluated — after the crash.

13 occurrences / 5 users impacted over the last 3 weeks.

Sentry issue: https://alastair-mcneill.sentry.io/issues/282-APP-103

## Fix
`lib/screens/munro_challenge/screens/munro_challenge_detail_screen.dart`: read `currentAchievement` without the null-check operator and use `?.annualTarget ?? 0`, so a null achievement is treated the same as a zero goal and renders the existing empty state instead of crashing.

## Testing
No test harness available in this sandbox (no `flutter`/`dart` binary); change is a 2-line null-safety fix that preserves existing behavior for the non-null case.

Fixes 282-APP-103

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhNujrD8Yw4mgGdCVsw3zS)_