### PR TITLE
Fix: guard against unmounted context after profile update (282-APP-104)

### DIFF
--- a/lib/screens/edit_profile/edit_profile_screen.dart
+++ b/lib/screens/edit_profile/edit_profile_screen.dart
@@ -85,6 +85,8 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                 profilePicture: _image,
               );
 
+              if (!mounted) return;
+
               context.read<Analytics>().track(
                 AnalyticsEvent.profileEditSaved,
                 props: {


### PR DESCRIPTION
## Problem
The save handler in `EditProfileScreen` used `BuildContext` (`context.read<Analytics>()`, `Navigator.of(context)`, `showErrorDialog`) after `await userState.updateProfile(...)` without checking whether the widget was still mounted. If the screen was disposed while that await was in flight (e.g. the user navigated away during the upload), the subsequent `context.read<Analytics>()` call threw inside `Provider._inheritedElementOf` (`TypeError: Null check operator used on a null value`).

6 occurrences / 3 users impacted over the last 3 weeks.

Sentry issue: https://alastair-mcneill.sentry.io/issues/282-APP-104

## Fix
`lib/screens/edit_profile/edit_profile_screen.dart`: add `if (!mounted) return;` immediately after the `await userState.updateProfile(...)` call, before any further use of `context`.

## Testing
No test harness available in this sandbox (no `flutter`/`dart` binary); change follows the standard Flutter "check mounted after an await" pattern used elsewhere in this codebase.

Fixes 282-APP-104

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhNujrD8Yw4mgGdCVsw3zS)_