### PR TITLE
Fix: crash rendering saved list when a saved munro is missing locally (282-APP-ZX)

### DIFF
--- a/lib/screens/saved/widgets/saved_list_tile.dart
+++ b/lib/screens/saved/widgets/saved_list_tile.dart
@@ -12,6 +12,9 @@ class SavedListTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final munroState = context.read<MunroState>();
+    // A saved munroId may not (yet) exist in munroState.munroList, e.g. while
+    // the munro list is still loading. Skip those rather than crashing.
+    final munroIds = savedList.munroIds.where((id) => munroState.munroList.any((m) => m.id == id)).toList();
     return Card(
       margin: EdgeInsets.zero,
       child: Padding(
@@ -20,16 +23,16 @@ class SavedListTile extends StatelessWidget {
           children: [
             SavedListHeader(savedList: savedList),
             const SizedBox(height: 10),
-            savedList.munroIds.isEmpty
+            munroIds.isEmpty
                 ? SavedListEmptyMunroList()
                 : ListView.separated(
                     shrinkWrap: true,
                     physics: NeverScrollableScrollPhysics(),
-                    itemCount: savedList.munroIds.length,
+                    itemCount: munroIds.length,
                     separatorBuilder: (context, index) => const SizedBox(height: 8),
                     itemBuilder: (context, index) {
-                      final munroId = savedList.munroIds[index];
-                      final Munro munro = munroState.munroList.where((m) => m.id == munroId).first;
+                      final munroId = munroIds[index];
+                      final Munro munro = munroState.munroList.firstWhere((m) => m.id == munroId);
                       return SavedListMunroTile(
                         munro: munro,
                         onDelete: () async {


### PR DESCRIPTION
## Problem
`SavedListTile` looked up each saved munro with `munroState.munroList.where((m) => m.id == munroId).first`, which throws `StateError: Bad state: No element` if `munroList` hasn't finished loading yet or a saved id is unexpectedly absent from it.

13 occurrences / 3 users impacted over the last 3+ weeks.

Sentry issue: https://alastair-mcneill.sentry.io/issues/282-APP-ZX

## Fix
`lib/screens/saved/widgets/saved_list_tile.dart`: filter `savedList.munroIds` down to ids that actually resolve in `munroState.munroList` before building the list, instead of crashing on the first unresolved id. Falls back to the existing empty-list state if none resolve.

## Testing
No test harness available in this sandbox (no `flutter`/`dart` binary); change is a defensive filter that doesn't alter behavior for the common case where all saved munros are present.

Fixes 282-APP-ZX

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhNujrD8Yw4mgGdCVsw3zS)_