### PR TITLE
Fix: crash when a completed munro's completion record isn't loaded yet (282-APP-10C)

### DIFF
--- a/lib/screens/profile/screens/munros_completed_screen.dart
+++ b/lib/screens/profile/screens/munros_completed_screen.dart
@@ -32,7 +32,14 @@ class MunrosCompletedScreen extends StatelessWidget {
     final completedIds =
         isCurrentUser ? munroCompletionState.completedMunroIds : munroCompletions.map((mc) => mc.munroId).toSet();
 
-    final completedMunros = munroState.munroList.where((m) => completedIds.contains(m.id)).toList();
+    // Only keep munros that also have a matching completion record — completedIds can
+    // momentarily be ahead of the munroCompletions passed in (e.g. right after a completion
+    // is added, before this screen's args are refreshed), and firstWhere below would
+    // otherwise throw for those ids.
+    final completedMunroIdsWithCompletion =
+        completedIds.where((id) => munroCompletions.any((mc) => mc.munroId == id)).toSet();
+    final completedMunros =
+        munroState.munroList.where((m) => completedMunroIdsWithCompletion.contains(m.id)).toList();
 
     final totalCount = munroState.munroList.length;
 


### PR DESCRIPTION
## Problem
`MunrosCompletedScreen` derives its set of completed munro ids from `munroCompletionState.completedMunroIds`, but then looks up each completion's details via `munroCompletions.firstWhere((mc) => mc.munroId == munro.id)` — a separately-sourced list (passed in as a screen argument) that can lag behind the live state, e.g. immediately after a new completion is recorded but before this screen's arguments are refreshed. When an id was present in `completedIds` but not yet in `munroCompletions`, `firstWhere` threw `StateError: Bad state: No element`.

Sentry issue: https://alastair-mcneill.sentry.io/issues/282-APP-10C

## Fix
`lib/screens/profile/screens/munros_completed_screen.dart`: only include munro ids that resolve in *both* `completedIds` and `munroCompletions` before rendering, so `firstWhere` can no longer miss.

## Testing
No test harness available in this sandbox (no `flutter`/`dart` binary); change is a defensive filter, no behavior change for the common case where both lists are in sync.

Fixes 282-APP-10C

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhNujrD8Yw4mgGdCVsw3zS)_