### PR TITLE
Fix: crash deleting a map annotation that's already gone in bulk-update map (282-APP-109)

### DIFF
--- a/lib/screens/bulk_munro_updates/widgets/bulk_munro_map_screen.dart
+++ b/lib/screens/bulk_munro_updates/widgets/bulk_munro_map_screen.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:two_eight_two/analytics/analytics.dart';
 import 'package:provider/provider.dart';
@@ -196,7 +197,11 @@ class _BulkMunroMapScreenState extends State<BulkMunroMapScreen> {
       mapStyle: mapStyle,
     );
 
-    await _annotationManager.delete(selectedAnnotation!);
+    try {
+      await _annotationManager.delete(selectedAnnotation!);
+    } on PlatformException {
+      // Annotation may already be gone (e.g. cleared by a concurrent refresh).
+    }
     final restored = await _annotationManager.create(PointAnnotationOptions(
       geometry: selectedAnnotation!.geometry,
       image: icon,
@@ -217,7 +222,11 @@ class _BulkMunroMapScreenState extends State<BulkMunroMapScreen> {
       orElse: () => Munro.empty,
     );
 
-    await _annotationManager.delete(tappedAnnotation);
+    try {
+      await _annotationManager.delete(tappedAnnotation);
+    } on PlatformException {
+      // Annotation may already be gone (e.g. cleared by a concurrent refresh).
+    }
     final newAnnotation = await _annotationManager.create(PointAnnotationOptions(
       geometry: tappedAnnotation.geometry,
       image: markerIcons!.selectedFor(munro.area, mapStyle),


### PR DESCRIPTION
## Problem
`BulkMunroMapScreen` called `_annotationManager.delete(...)` directly in `_deselectAnnotation` and `_selectAnnotation` with no error handling. If a concurrent operation (e.g. a refresh triggered by the filtered munro list changing) had already removed that annotation from the native Mapbox layer, `delete()` throws `PlatformException('Annotation has not been added on the map: ...')`, crashing the tap handler.

`mapbox_map_screen.dart` (the main explore map) already guards its equivalent `delete()` calls against exactly this race — this PR applies the same `try/catch` there.

Sentry issue: https://alastair-mcneill.sentry.io/issues/282-APP-109

## Fix
`lib/screens/bulk_munro_updates/widgets/bulk_munro_map_screen.dart`: wrap both unguarded `_annotationManager.delete(...)` calls in `try { ... } on PlatformException { }`, matching the established pattern in the sibling screen. Adds the `flutter/services.dart` import needed for `PlatformException`.

## Testing
No test harness available in this sandbox (no `flutter`/`dart` binary); change mirrors an existing, working pattern already used elsewhere in the codebase for the identical native race.

Fixes 282-APP-109

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhNujrD8Yw4mgGdCVsw3zS)_