### PR TITLE
Fix: LateInitializationError on _mapboxMap when brightness changes early (282-APP-10P)

### DIFF
--- a/lib/screens/explore/screens/mapbox_map_screen.dart
+++ b/lib/screens/explore/screens/mapbox_map_screen.dart
@@ -70,7 +70,7 @@ class _MapboxMapScreenState extends State<MapboxMapScreen> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     final brightness = Theme.of(context).brightness;
-    if (_lastBrightness != null && _lastBrightness != brightness) {
+    if (_lastBrightness != null && _lastBrightness != brightness && _mapInitialized) {
       final uri = brightness == Brightness.dark ? _darkStyleUri : _lightStyleUri;
       _mapboxMap.loadStyleURI(uri);
     }


### PR DESCRIPTION
## Problem
`_MapboxMapScreenState.didChangeDependencies` accessed the `late MapboxMap _mapboxMap` field whenever the brightness changed, but that field isn't set until `_onMapCreated` fires after the native map finishes creating. A brightness/theme change (or any other dependency change) that happens before that point threw `LateError: Field '_mapboxMap' has not been initialized.`

The sibling `BulkMunroMapScreen` already guards its equivalent `didChangeDependencies` logic with an `_mapInitialized` check — this PR applies the same guard to the main explore map screen.

Sentry issue: https://alastair-mcneill.sentry.io/issues/282-APP-10P

## Fix
`lib/screens/explore/screens/mapbox_map_screen.dart`: add `&& _mapInitialized` to the condition before touching `_mapboxMap` in `didChangeDependencies`.

## Testing
No test harness available in this sandbox (no `flutter`/`dart` binary); one-line guard mirroring an existing, working pattern in the sibling screen.

Fixes 282-APP-10P

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhNujrD8Yw4mgGdCVsw3zS)_