### PR TITLE
Fix: retry transient network errors on onboarding feed and post feeds (282-APP-PN, ZJ, 105, SZ)

### DIFF
--- a/lib/helpers/helpers.dart
+++ b/lib/helpers/helpers.dart
@@ -2,3 +2,4 @@ export 'device_info_helper.dart';
 export 'image_helper.dart';
 export 'image_picker_helper.dart';
 export 'munro_marker_icon_helper.dart';
+export 'network_retry_helper.dart';

--- a/lib/helpers/network_retry_helper.dart
+++ b/lib/helpers/network_retry_helper.dart
@@ -1,0 +1,39 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:http/http.dart' show ClientException;
+
+/// Retries [action] when it fails with a transient, connection-level error —
+/// the kind that shows up as OSError/SocketException/HandshakeException/
+/// ClientException/TimeoutException from the underlying HTTP client, most
+/// commonly right after the app resumes from the background and reuses a
+/// socket the OS has already torn down. Anything else (e.g. a Postgrest
+/// error response, a programming error) is rethrown immediately.
+///
+/// Uses a short, fixed number of retries with a small linear backoff — this
+/// is meant to smooth over a single flaky reconnect, not to paper over a
+/// genuinely unreachable server.
+Future<T> withNetworkRetry<T>(
+  Future<T> Function() action, {
+  int retries = 2,
+  Duration delay = const Duration(milliseconds: 400),
+}) async {
+  var attempt = 0;
+  while (true) {
+    try {
+      return await action();
+    } catch (error) {
+      if (attempt >= retries || !_isTransientNetworkError(error)) rethrow;
+      attempt++;
+      await Future.delayed(delay * attempt);
+    }
+  }
+}
+
+bool _isTransientNetworkError(Object error) {
+  return error is SocketException ||
+      error is OSError ||
+      error is HandshakeException ||
+      error is TimeoutException ||
+      error is ClientException;
+}

--- a/lib/helpers/network_retry_helper.dart
+++ b/lib/helpers/network_retry_helper.dart
@@ -3,16 +3,6 @@ import 'dart:io';
 
 import 'package:http/http.dart' show ClientException;
 
-/// Retries [action] when it fails with a transient, connection-level error —
-/// the kind that shows up as OSError/SocketException/HandshakeException/
-/// ClientException/TimeoutException from the underlying HTTP client, most
-/// commonly right after the app resumes from the background and reuses a
-/// socket the OS has already torn down. Anything else (e.g. a Postgrest
-/// error response, a programming error) is rethrown immediately.
-///
-/// Uses a short, fixed number of retries with a small linear backoff — this
-/// is meant to smooth over a single flaky reconnect, not to paper over a
-/// genuinely unreachable server.
 Future<T> withNetworkRetry<T>(
   Future<T> Function() action, {
   int retries = 2,

--- a/lib/repos/onboarding_repository.dart
+++ b/lib/repos/onboarding_repository.dart
@@ -11,10 +11,6 @@ class OnboardingRepository {
   SupabaseQueryBuilder get _totals => _db.from('vu_onboarding_totals');
   SupabaseQueryBuilder get _acheivements => _db.from('vu_onboarding_achievements');
 
-  // Onboarding runs right after app launch, often just as the OS finishes
-  // handing the process its network interface back — that's exactly when a
-  // reused connection is most likely to have gone stale underneath us, so
-  // these reads get one short retry on transient connection errors.
   Future<List<OnboardingFeedPost>> fetchFeedPosts() async {
     final response = await withNetworkRetry(() => _posts.select());
 

--- a/lib/repos/onboarding_repository.dart
+++ b/lib/repos/onboarding_repository.dart
@@ -1,4 +1,5 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:two_eight_two/helpers/helpers.dart';
 import 'package:two_eight_two/models/models.dart';
 
 class OnboardingRepository {
@@ -10,20 +11,24 @@ class OnboardingRepository {
   SupabaseQueryBuilder get _totals => _db.from('vu_onboarding_totals');
   SupabaseQueryBuilder get _acheivements => _db.from('vu_onboarding_achievements');
 
+  // Onboarding runs right after app launch, often just as the OS finishes
+  // handing the process its network interface back — that's exactly when a
+  // reused connection is most likely to have gone stale underneath us, so
+  // these reads get one short retry on transient connection errors.
   Future<List<OnboardingFeedPost>> fetchFeedPosts() async {
-    final response = await _posts.select();
+    final response = await withNetworkRetry(() => _posts.select());
 
     return response.map((e) => OnboardingFeedPost.fromMap(e)).toList();
   }
 
   Future<OnboardingTotals> fetchTotals() async {
-    final response = await _totals.select().single();
+    final response = await withNetworkRetry(() => _totals.select().single());
 
     return OnboardingTotals.fromMap(response);
   }
 
   Future<List<OnboardingAchievements>> fetchAchievements() async {
-    final response = await _acheivements.select();
+    final response = await withNetworkRetry(() => _acheivements.select());
 
     return response.map((e) => OnboardingAchievements.fromMap(e)).toList();
   }

--- a/lib/repos/posts_repository.dart
+++ b/lib/repos/posts_repository.dart
@@ -1,4 +1,5 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:two_eight_two/helpers/helpers.dart';
 import 'package:two_eight_two/models/models.dart';
 
 class PostsRepository {
@@ -53,15 +54,17 @@ class PostsRepository {
     required List<String> excludedAuthorIds,
     Post? lastPost,
   }) async {
-    final List<dynamic> response = await _db.rpc(
-      'get_friends_feed',
-      params: {
-        'p_limit': 10,
-        'p_before_date_time': lastPost?.dateTimeCreated.toUtc().toIso8601String(),
-        'p_before_id': lastPost?.uid,
-        'p_excluded_author_ids': excludedAuthorIds,
-      },
-    ).timeout(Duration(seconds: 30));
+    final List<dynamic> response = await withNetworkRetry(
+      () => _db.rpc(
+        'get_friends_feed',
+        params: {
+          'p_limit': 10,
+          'p_before_date_time': lastPost?.dateTimeCreated.toUtc().toIso8601String(),
+          'p_before_id': lastPost?.uid,
+          'p_excluded_author_ids': excludedAuthorIds,
+        },
+      ).timeout(Duration(seconds: 30)),
+    );
 
     return response.map((doc) => Post.fromJSON(doc as Map<String, dynamic>)).toList();
   }
@@ -71,15 +74,17 @@ class PostsRepository {
     required List<String> excludedAuthorIds,
     Post? lastPost,
   }) async {
-    final List<dynamic> response = await _db.rpc(
-      'get_global_feed',
-      params: {
-        'p_limit': 10,
-        'p_before_date_time': lastPost?.dateTimeCreated.toUtc().toIso8601String(),
-        'p_before_id': lastPost?.uid,
-        'p_excluded_author_ids': excludedAuthorIds,
-      },
-    ).timeout(Duration(seconds: 30));
+    final List<dynamic> response = await withNetworkRetry(
+      () => _db.rpc(
+        'get_global_feed',
+        params: {
+          'p_limit': 10,
+          'p_before_date_time': lastPost?.dateTimeCreated.toUtc().toIso8601String(),
+          'p_before_id': lastPost?.uid,
+          'p_excluded_author_ids': excludedAuthorIds,
+        },
+      ).timeout(Duration(seconds: 30)),
+    );
 
     return response.map((doc) => Post.fromJSON(doc as Map<String, dynamic>)).toList();
   }

--- a/test/helpers/network_retry_helper_test.dart
+++ b/test/helpers/network_retry_helper_test.dart
@@ -1,0 +1,105 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' show ClientException;
+import 'package:two_eight_two/helpers/helpers.dart';
+
+void main() {
+  group('withNetworkRetry', () {
+    test('returns the result on first success without retrying', () async {
+      var calls = 0;
+      final result = await withNetworkRetry(() async {
+        calls++;
+        return 'ok';
+      });
+
+      expect(result, 'ok');
+      expect(calls, 1);
+    });
+
+    test('retries a transient SocketException and succeeds', () async {
+      var calls = 0;
+      final result = await withNetworkRetry(
+        () async {
+          calls++;
+          if (calls == 1) {
+            throw const SocketException('Bad file descriptor');
+          }
+          return 'ok';
+        },
+        delay: Duration.zero,
+      );
+
+      expect(result, 'ok');
+      expect(calls, 2);
+    });
+
+    test('retries an OSError up to the retry limit then rethrows', () async {
+      var calls = 0;
+      await expectLater(
+        () => withNetworkRetry<void>(
+          () async {
+            calls++;
+            throw const OSError('Bad file descriptor', 9);
+          },
+          retries: 2,
+          delay: Duration.zero,
+        ),
+        throwsA(isA<OSError>()),
+      );
+
+      expect(calls, 3); // initial attempt + 2 retries
+    });
+
+    test('retries a ClientException from package:http', () async {
+      var calls = 0;
+      final result = await withNetworkRetry(
+        () async {
+          calls++;
+          if (calls == 1) {
+            throw ClientException('Connection closed while receiving data');
+          }
+          return 'ok';
+        },
+        delay: Duration.zero,
+      );
+
+      expect(result, 'ok');
+      expect(calls, 2);
+    });
+
+    test('does not retry a non-transient error', () async {
+      var calls = 0;
+      await expectLater(
+        () => withNetworkRetry<void>(
+          () async {
+            calls++;
+            throw ArgumentError('not a network problem');
+          },
+          delay: Duration.zero,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      expect(calls, 1);
+    });
+
+    test('gives up after exhausting retries', () async {
+      var calls = 0;
+      await expectLater(
+        () => withNetworkRetry<void>(
+          () async {
+            calls++;
+            throw const SocketException('still offline');
+          },
+          retries: 3,
+          delay: Duration.zero,
+        ),
+        throwsA(isA<SocketException>()),
+      );
+
+      expect(calls, 4); // initial attempt + 3 retries
+    });
+  });
+}


### PR DESCRIPTION
## Problem
Several of the highest-volume unresolved Sentry issues are the same underlying problem hitting different endpoints: a Postgrest/RPC call fails with a low-level, clearly transient connection error — `OSError: Bad file descriptor`, `SocketException: Connection refused`, `HandshakeException`, `ClientException: Connection closed while receiving data` — most commonly right as the app resumes from the background and reuses a socket the OS has already torn down underneath it. These aren't logic bugs; they're single flaky reconnects that a retry resolves.

- https://alastair-mcneill.sentry.io/issues/282-APP-PN (OSError Bad file descriptor reading `vu_onboarding_feed`, 154 occurrences / 22 users)
- https://alastair-mcneill.sentry.io/issues/282-APP-ZJ (same signature)
- https://alastair-mcneill.sentry.io/issues/282-APP-105 (`get_friends_feed` RPC connection refused)
- https://alastair-mcneill.sentry.io/issues/282-APP-SZ (`get_global_feed` RPC connection refused)

## Fix
Added `lib/helpers/network_retry_helper.dart`: `withNetworkRetry()` retries an action up to 2 times with linear backoff, but only for those specific transient error types (`SocketException`, `OSError`, `HandshakeException`, `TimeoutException`, `ClientException`) — anything else (a real Postgrest error response, a programming error) is rethrown immediately on the first attempt.

Applied it to the exact call sites identified from the Sentry stack traces:
- `OnboardingRepository.fetchFeedPosts` / `fetchTotals` / `fetchAchievements`
- `PostsRepository.getFriendsFeed` / `getGlobalFeed`

## Testing
No test harness available in this sandbox (no `flutter`/`dart` binary). Added `test/helpers/network_retry_helper_test.dart` covering the retry/no-retry decision for each error type and the retry-exhaustion path, as a substitute for running the suite myself.

Fixes 282-APP-PN, 282-APP-ZJ, 282-APP-105, 282-APP-SZ

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhNujrD8Yw4mgGdCVsw3zS)_