### PR TITLE
Fix: don't report sign-in cancellation as a Sentry error (282-APP-ZQ, 101)

### DIFF
--- a/lib/screens/auth/state/auth_state.dart
+++ b/lib/screens/auth/state/auth_state.dart
@@ -289,14 +289,14 @@ class AuthState extends ChangeNotifier {
       _setAuthenticated();
       return AuthResult(success: true, showOnboarding: showOnboarding, userId: currentUserId);
     } on SignInWithAppleAuthorizationException catch (e, st) {
-      _logger.error(e.toString(), stackTrace: st);
-
       if (e.code == AuthorizationErrorCode.canceled) {
+        // The user dismissed the Apple sign-in sheet — expected, not an error.
         _status = AuthStatus.initial;
         notifyListeners();
         return AuthResult(success: false, canceled: true);
       }
 
+      _logger.error(e.toString(), stackTrace: st);
       _setError(e.message);
       return AuthResult(
         success: false,
@@ -383,13 +383,14 @@ class AuthState extends ChangeNotifier {
       _setAuthenticated();
       return AuthResult(success: true, showOnboarding: showOnboarding, userId: currentUserId);
     } on GoogleSignInException catch (e, st) {
-      _logger.error("Google Sign In Error: $e", stackTrace: st);
       if (e.code == GoogleSignInExceptionCode.canceled) {
+        // The user dismissed the Google sign-in sheet — expected, not an error.
         _status = AuthStatus.initial;
         notifyListeners();
         return AuthResult(success: false, canceled: true);
       }
 
+      _logger.error("Google Sign In Error: $e", stackTrace: st);
       _setError("There was an error signing in with Google.");
       return AuthResult(
         success: false,


### PR DESCRIPTION
## Problem
`signInWithApple()` and `signInWithGoogle()` already correctly detect a canceled sign-in sheet and return `AuthResult(canceled: true)` so the UI treats it as a no-op rather than an error — but both logged the exception via `Logger.error()` unconditionally, before checking whether it was a cancellation. `Logger.error()` reports to Sentry, so every time a user backed out of the Google or Apple sign-in sheet, that ordinary action was recorded as an unresolved production error.

- https://alastair-mcneill.sentry.io/issues/282-APP-ZQ (Google, 27 occurrences / 26 users)
- https://alastair-mcneill.sentry.io/issues/282-APP-101 (Apple, 4 occurrences / 2 users)

## Fix
`lib/screens/auth/state/auth_state.dart`: move the `logger.error()` call after the cancellation check in both `signInWithApple` and `signInWithGoogle`, so only genuine sign-in failures get logged/reported; a user tapping "Cancel" no longer creates a Sentry issue.

## Testing
No test harness available in this sandbox (no `flutter`/`dart` binary), and there's no existing `auth_state_test.dart` to update. The change reorders two statements within an existing catch block without altering the returned `AuthResult` in either branch.

Fixes 282-APP-ZQ, 282-APP-101

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhNujrD8Yw4mgGdCVsw3zS)_