### PR TITLE
Fix: don't let a transient map platform-channel failure crash the app (282-APP-10E, 10M, 10Y, 10Z)

### DIFF
--- a/lib/screens/bulk_munro_updates/widgets/bulk_munro_map_screen.dart
+++ b/lib/screens/bulk_munro_updates/widgets/bulk_munro_map_screen.dart
@@ -6,6 +6,7 @@ import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:two_eight_two/analytics/analytics.dart';
 import 'package:provider/provider.dart';
 import 'package:two_eight_two/helpers/helpers.dart';
+import 'package:two_eight_two/logging/logging.dart';
 import 'package:two_eight_two/models/models.dart';
 import 'package:two_eight_two/screens/bulk_munro_updates/widgets/bulk_munro_map_summary_card.dart';
 import 'package:two_eight_two/screens/notifiers.dart';
@@ -80,20 +81,36 @@ class _BulkMunroMapScreenState extends State<BulkMunroMapScreen> {
 
   void _onMapCreated(MapboxMap mapboxMap, MunroState munroState, MunroCompletionState munroCompletionState,
       BulkMunroUpdateState bulkMunroUpdateState) async {
-    final mapStyle = context.read<SettingsState>().mapStyleSetting;
-    _mapboxMap = mapboxMap;
-    await mapboxMap.compass.updateSettings(CompassSettings(enabled: false));
-    await mapboxMap.scaleBar.updateSettings(ScaleBarSettings(enabled: false));
-    _mapboxMap.setBounds(cameraBounds);
-    await _addMunroSymbols(
-      munros: munroState.munroList,
-      munroCompletionState: munroCompletionState,
-      bulkMunroUpdateState: bulkMunroUpdateState,
-      mapStyle: mapStyle,
-    );
-    _lastMunroIds = munroState.munroList.map((m) => m.id).toList();
-    _lastMapStyle = mapStyle;
-    _mapInitialized = true;
+    // onMapCreated is a fire-and-forget callback (async void) — an uncaught
+    // exception here crashes the whole app rather than just this screen.
+    // The native map channels can occasionally fail to establish right at
+    // startup (PlatformException channel-error, MissingPluginException on
+    // slower devices), so guard the whole setup sequence and degrade to a
+    // plain, unconfigured map instead of taking the app down.
+    try {
+      final mapStyle = context.read<SettingsState>().mapStyleSetting;
+      _mapboxMap = mapboxMap;
+      await mapboxMap.compass.updateSettings(CompassSettings(enabled: false));
+      await mapboxMap.scaleBar.updateSettings(ScaleBarSettings(enabled: false));
+      _mapboxMap.setBounds(cameraBounds);
+      await _addMunroSymbols(
+        munros: munroState.munroList,
+        munroCompletionState: munroCompletionState,
+        bulkMunroUpdateState: bulkMunroUpdateState,
+        mapStyle: mapStyle,
+      );
+      _lastMunroIds = munroState.munroList.map((m) => m.id).toList();
+      _lastMapStyle = mapStyle;
+      _mapInitialized = true;
+    } catch (error, stackTrace) {
+      if (mounted) {
+        context.read<Logger>().error(
+              'Failed to finish setting up the bulk-update map',
+              error: error,
+              stackTrace: stackTrace,
+            );
+      }
+    }
   }
 
   Future<void> _addMunroSymbols({

--- a/lib/screens/bulk_munro_updates/widgets/bulk_munro_map_screen.dart
+++ b/lib/screens/bulk_munro_updates/widgets/bulk_munro_map_screen.dart
@@ -81,12 +81,6 @@ class _BulkMunroMapScreenState extends State<BulkMunroMapScreen> {
 
   void _onMapCreated(MapboxMap mapboxMap, MunroState munroState, MunroCompletionState munroCompletionState,
       BulkMunroUpdateState bulkMunroUpdateState) async {
-    // onMapCreated is a fire-and-forget callback (async void) — an uncaught
-    // exception here crashes the whole app rather than just this screen.
-    // The native map channels can occasionally fail to establish right at
-    // startup (PlatformException channel-error, MissingPluginException on
-    // slower devices), so guard the whole setup sequence and degrade to a
-    // plain, unconfigured map instead of taking the app down.
     try {
       final mapStyle = context.read<SettingsState>().mapStyleSetting;
       _mapboxMap = mapboxMap;

--- a/lib/screens/explore/screens/mapbox_map_screen.dart
+++ b/lib/screens/explore/screens/mapbox_map_screen.dart
@@ -7,6 +7,7 @@ import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:two_eight_two/analytics/analytics.dart';
 import 'package:provider/provider.dart';
 import 'package:two_eight_two/helpers/helpers.dart';
+import 'package:two_eight_two/logging/logging.dart';
 import 'package:two_eight_two/models/models.dart';
 import 'package:two_eight_two/screens/explore/screens/map_shimmer_loader.dart';
 import 'package:two_eight_two/screens/notifiers.dart';
@@ -83,22 +84,38 @@ class _MapboxMapScreenState extends State<MapboxMapScreen> {
   }
 
   void _onMapCreated(MapboxMap mapboxMap, MunroState munroState, MunroCompletionState munroCompletionState) async {
-    final mapStyle = context.read<SettingsState>().mapStyleSetting;
-    _mapboxMap = mapboxMap;
-    await mapboxMap.compass.updateSettings(CompassSettings(enabled: false));
-    await mapboxMap.scaleBar.updateSettings(ScaleBarSettings(enabled: false));
-    await mapboxMap.gestures.updateSettings(
-      GesturesSettings(rotateEnabled: false, pitchEnabled: false),
-    );
-    _mapboxMap.setBounds(cameraBounds);
-    await _addMunroSymbols(
-      munroState: munroState,
-      completedMunros: munroCompletionState.munroCompletions,
-      mapStyle: mapStyle,
-    );
-    _lastFilteredIds = munroState.filteredMunroList.map((m) => m.id).toList();
-    _lastMapStyle = mapStyle;
-    _mapInitialized = true;
+    // onMapCreated is a fire-and-forget callback (async void) — an uncaught
+    // exception here crashes the whole app rather than just this screen.
+    // The native map channels can occasionally fail to establish right at
+    // startup (PlatformException channel-error, MissingPluginException on
+    // slower devices), so guard the whole setup sequence and degrade to a
+    // plain, unconfigured map instead of taking the app down.
+    try {
+      final mapStyle = context.read<SettingsState>().mapStyleSetting;
+      _mapboxMap = mapboxMap;
+      await mapboxMap.compass.updateSettings(CompassSettings(enabled: false));
+      await mapboxMap.scaleBar.updateSettings(ScaleBarSettings(enabled: false));
+      await mapboxMap.gestures.updateSettings(
+        GesturesSettings(rotateEnabled: false, pitchEnabled: false),
+      );
+      _mapboxMap.setBounds(cameraBounds);
+      await _addMunroSymbols(
+        munroState: munroState,
+        completedMunros: munroCompletionState.munroCompletions,
+        mapStyle: mapStyle,
+      );
+      _lastFilteredIds = munroState.filteredMunroList.map((m) => m.id).toList();
+      _lastMapStyle = mapStyle;
+      _mapInitialized = true;
+    } catch (error, stackTrace) {
+      if (mounted) {
+        context.read<Logger>().error(
+              'Failed to finish setting up the explore map',
+              error: error,
+              stackTrace: stackTrace,
+            );
+      }
+    }
   }
 
   Future<void> _addMunroSymbols(

--- a/lib/screens/explore/screens/mapbox_map_screen.dart
+++ b/lib/screens/explore/screens/mapbox_map_screen.dart
@@ -84,12 +84,6 @@ class _MapboxMapScreenState extends State<MapboxMapScreen> {
   }
 
   void _onMapCreated(MapboxMap mapboxMap, MunroState munroState, MunroCompletionState munroCompletionState) async {
-    // onMapCreated is a fire-and-forget callback (async void) — an uncaught
-    // exception here crashes the whole app rather than just this screen.
-    // The native map channels can occasionally fail to establish right at
-    // startup (PlatformException channel-error, MissingPluginException on
-    // slower devices), so guard the whole setup sequence and degrade to a
-    // plain, unconfigured map instead of taking the app down.
     try {
       final mapStyle = context.read<SettingsState>().mapStyleSetting;
       _mapboxMap = mapboxMap;
@@ -119,7 +113,9 @@ class _MapboxMapScreenState extends State<MapboxMapScreen> {
   }
 
   Future<void> _addMunroSymbols(
-      {required MunroState munroState, required List<MunroCompletion> completedMunros, required String mapStyle}) async {
+      {required MunroState munroState,
+      required List<MunroCompletion> completedMunros,
+      required String mapStyle}) async {
     final List<Munro> munros = munroState.filteredMunroList;
     final icons = markerIcons;
 


### PR DESCRIPTION
## Problem
`_onMapCreated` is a fire-and-forget (`async void`) `MapWidget` callback — any exception thrown inside it, or anything it awaits, is uncaught and reaches `PlatformDispatcher.onError` as a fatal, app-crashing error. On slower devices the native Mapbox platform channels can intermittently fail to establish right at map startup:

- https://alastair-mcneill.sentry.io/issues/282-APP-10E (`PlatformException channel-error` on `GesturesSettingsInterface.updateSettings`)
- https://alastair-mcneill.sentry.io/issues/282-APP-10M (`_PointAnnotationMessenger.createMulti`)
- https://alastair-mcneill.sentry.io/issues/282-APP-10Y (`_CameraManager.setBounds`)
- https://alastair-mcneill.sentry.io/issues/282-APP-10Z (`MissingPluginException` on `createPointAnnotationManager`)

10Y and 10Z share the exact same `trace_id` (same device, same session) — one bad map-init moment throwing more than once, confirming the failure mode is the whole `_onMapCreated` setup sequence, not any single call.

## Fix
Wrap the whole `_onMapCreated` setup sequence in both map screens in `try/catch`: log the failure via the app's `Logger` and let the map render unconfigured rather than crashing the app. Applied to both the explore map (`mapbox_map_screen.dart`) and the bulk-update map screen (`bulk_munro_map_screen.dart`), since they share the same setup pattern and plugin.

## Testing
No test harness available in this sandbox (no `flutter`/`dart` binary), and there are no existing tests for either map screen. The change only adds a try/catch around existing logic — no behavioral change on the success path.

Fixes 282-APP-10E, 282-APP-10M, 282-APP-10Y, 282-APP-10Z

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhNujrD8Yw4mgGdCVsw3zS)_