### PR TITLE
Fix: stop reporting recovered remote-config timeouts as Sentry errors (282-APP-PX)

### DIFF
--- a/lib/screens/nav/state/remote_config_state.dart
+++ b/lib/screens/nav/state/remote_config_state.dart
@@ -30,11 +30,18 @@ class RemoteConfigState extends ChangeNotifier {
       _status = RemoteConfigStatus.loaded;
     } catch (error, stackTrace) {
       _error = Error(message: error.toString());
-      _logger.error('Failed to initialize remote config: $error', stackTrace: stackTrace);
+      // Not reported as an error: fetching remote config can time out on a slow
+      // cold-start connection, but we always fall back to the built-in defaults
+      // below and nothing in the UI branches on RemoteConfigStatus.error, so this
+      // never actually degrades the app. Logging it as info keeps it visible as
+      // context on any other error in the session without paging anyone for a
+      // condition that already fully recovered.
+      _logger.info('Failed to initialize remote config, falling back to defaults: $error', context: {
+        'stackTrace': stackTrace.toString(),
+      });
       _config = _readConfigSnapshot();
       _status = RemoteConfigStatus.error;
     } finally {
-      print("🎯 ~ RemoteConfigState ~ init ~ _config: $_config");
       notifyListeners();
     }
   }

--- a/lib/screens/nav/state/remote_config_state.dart
+++ b/lib/screens/nav/state/remote_config_state.dart
@@ -30,12 +30,6 @@ class RemoteConfigState extends ChangeNotifier {
       _status = RemoteConfigStatus.loaded;
     } catch (error, stackTrace) {
       _error = Error(message: error.toString());
-      // Not reported as an error: fetching remote config can time out on a slow
-      // cold-start connection, but we always fall back to the built-in defaults
-      // below and nothing in the UI branches on RemoteConfigStatus.error, so this
-      // never actually degrades the app. Logging it as info keeps it visible as
-      // context on any other error in the session without paging anyone for a
-      // condition that already fully recovered.
       _logger.info('Failed to initialize remote config, falling back to defaults: $error', context: {
         'stackTrace': stackTrace.toString(),
       });

--- a/test/screens/nav/state/remote_config_state_test.dart
+++ b/test/screens/nav/state/remote_config_state_test.dart
@@ -129,10 +129,11 @@ void main() {
         expect(remoteConfigState.config.whatsNew, 'Hello');
         expect(remoteConfigState.config.groupFilterNewIcon, false);
 
-        verify(mockLogger.error(
-          'Failed to initialize remote config: $exception',
-          stackTrace: anyNamed('stackTrace'),
+        verify(mockLogger.info(
+          'Failed to initialize remote config, falling back to defaults: $exception',
+          context: anyNamed('context'),
         )).called(1);
+        verifyNever(mockLogger.error(any, error: anyNamed('error'), stackTrace: anyNamed('stackTrace')));
 
         verify(mockRemoteConfigRespository.getInt(RCFields.feedbackSurveyNumber)).called(1);
         verify(mockRemoteConfigRespository.getString(RCFields.latestAppVersion)).called(1);


### PR DESCRIPTION
## Problem
`RemoteConfigState.init()` already handles a failed Firebase Remote Config fetch correctly: it falls back to the built-in `RemoteConfig.defaultConfig` snapshot and never rethrows, so `Future.wait()` in `AppBootstrapState.init()` completes normally and the app starts up fine either way. Nothing in the UI even reads `RemoteConfigStatus.error`.

But the catch block called `logger.error()`, which reports to Sentry — so a transient fetch timeout on a slow cold-start connection (Prod's #2 issue by volume: 132 occurrences / 22 users) was recorded as an unresolved production error every time, despite the app fully recovering via defaults.

Sentry issue: https://alastair-mcneill.sentry.io/issues/282-APP-PX

## Fix
`lib/screens/nav/state/remote_config_state.dart`: log it as `info` instead of `error` — still visible as breadcrumb context on any other error in the session, without paging anyone for a condition that already self-healed. Also removed a stray debug `print()` left in the same block.

Updated `test/screens/nav/state/remote_config_state_test.dart` to assert the new `logger.info(...)` call instead of `logger.error(...)`.

## Testing
No test harness available in this sandbox (no `flutter`/`dart` binary). Updated the one existing test that asserted on the old `logger.error()` call.

Fixes 282-APP-PX

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhNujrD8Yw4mgGdCVsw3zS)_