### PR TITLE
Fix: don't report expected Firebase auth failures as Sentry errors (282-APP-108, RX)

### DIFF
--- a/lib/screens/auth/state/auth_state.dart
+++ b/lib/screens/auth/state/auth_state.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -55,6 +56,30 @@ class AuthState extends ChangeNotifier {
     _status = AuthStatus.authenticated;
     _errorMessage = null;
     notifyListeners();
+  }
+
+  // Firebase auth codes that represent an expected, user-caused condition
+  // (wrong password, needs to sign in again before a sensitive action, etc.)
+  // rather than an app bug. These are still surfaced to the user via
+  // _setError — they just aren't reported to Sentry as production errors.
+  static const _expectedAuthErrorCodes = {
+    'invalid-credential',
+    'wrong-password',
+    'user-not-found',
+    'user-mismatch',
+    'requires-recent-login',
+    'too-many-requests',
+    'email-already-in-use',
+    'weak-password',
+    'invalid-email',
+  };
+
+  void _logAuthError(Object error, StackTrace stackTrace) {
+    if (error is FirebaseAuthException && _expectedAuthErrorCodes.contains(error.code)) {
+      _logger.info('Expected auth error: $error');
+    } else {
+      _logger.error(error.toString(), stackTrace: stackTrace);
+    }
   }
 
   @override
@@ -162,7 +187,7 @@ class AuthState extends ChangeNotifier {
       _setAuthenticated();
       return AuthResult(success: true, showOnboarding: showOnboarding, userId: currentUserId);
     } catch (e, st) {
-      _logger.error(e.toString(), stackTrace: st);
+      _logAuthError(e, st);
       _setError(e.toString());
       return AuthResult(success: false, errorMessage: e.toString());
     }
@@ -198,7 +223,7 @@ class AuthState extends ChangeNotifier {
       _setAuthenticated();
       return AuthResult(success: true, showOnboarding: showOnboarding, userId: currentUserId);
     } catch (e, st) {
-      _logger.error(e.toString(), stackTrace: st);
+      _logAuthError(e, st);
       _setError(e.toString());
       return AuthResult(success: false, errorMessage: e.toString());
     }
@@ -410,7 +435,7 @@ class AuthState extends ChangeNotifier {
       notifyListeners();
       return AuthResult(success: true);
     } catch (e, st) {
-      _logger.error(e.toString(), stackTrace: st);
+      _logAuthError(e, st);
       _setError(e.toString());
       return AuthResult(success: false, errorMessage: e.toString());
     }
@@ -444,7 +469,7 @@ class AuthState extends ChangeNotifier {
       notifyListeners();
       return AuthResult(success: true);
     } catch (e, st) {
-      _logger.error(e.toString(), stackTrace: st);
+      _logAuthError(e, st);
       _setError(e.toString());
       return AuthResult(success: false, errorMessage: e.toString());
     }
@@ -462,7 +487,7 @@ class AuthState extends ChangeNotifier {
       notifyListeners();
       return AuthResult(success: true);
     } catch (e, st) {
-      _logger.error(e.toString(), stackTrace: st);
+      _logAuthError(e, st);
       _setError(e.toString());
       return AuthResult(success: false, errorMessage: e.toString());
     }


### PR DESCRIPTION
## Problem
`registerWithEmail`, `signInWithEmail`, `forgotPassword`, `signOut`, and `deleteUser` all already surface auth failures to the user correctly via `_setError()`, but logged every failure through `logger.error()` regardless of cause — so routine, user-caused conditions were reported as unresolved production errors:

- https://alastair-mcneill.sentry.io/issues/282-APP-108 — wrong/expired password (`firebase_auth/invalid-credential`, 10 occurrences / 5 users)
- https://alastair-mcneill.sentry.io/issues/282-APP-RX — needing to re-authenticate before deleting an account (`firebase_auth/requires-recent-login`, 18 occurrences / 2 users)

## Fix
`lib/screens/auth/state/auth_state.dart`: added `_logAuthError()`, which logs known user-caused `FirebaseAuthException` codes (`invalid-credential`, `wrong-password`, `user-not-found`, `requires-recent-login`, `too-many-requests`, `email-already-in-use`, `weak-password`, `invalid-email`) as `info` instead of `error`, and leaves everything else (genuine bugs, network failures) reported as before. Applied to the five call sites above.

Deliberately left the Apple/Google sign-in catch blocks in this file alone — they're addressed by the dedicated cancellation fix in #165 (282-APP-ZQ/101), to keep these two PRs from touching the same lines.

## Testing
No test harness available in this sandbox (no `flutter`/`dart` binary), and there's no existing `auth_state_test.dart` to update. `firebase_auth` is already a direct dependency used elsewhere in this file's call chain (`AuthRepository`), so `FirebaseAuthException` is a safe type to reference here.

Fixes 282-APP-108, 282-APP-RX

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhNujrD8Yw4mgGdCVsw3zS)_