### PR TITLE
Fix: don't report transient network failures as Sentry errors (282-APP-GX, ZY, V0, 10J, Y7, H0, HM, 10N, ZK, PQ, MK, WT, WZ)

### DIFF
--- a/lib/helpers/helpers.dart
+++ b/lib/helpers/helpers.dart
@@ -2,3 +2,4 @@ export 'device_info_helper.dart';
 export 'image_helper.dart';
 export 'image_picker_helper.dart';
 export 'munro_marker_icon_helper.dart';
+export 'network_error_helper.dart';

--- a/lib/helpers/network_error_helper.dart
+++ b/lib/helpers/network_error_helper.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+import 'dart:io';
+
+/// Returns true if [error] looks like a transient network failure — a
+/// dropped connection, DNS hiccup, TLS handshake failure, or timeout — as
+/// opposed to a genuine application bug.
+///
+/// These conditions are outside the app's control (poor signal, a flaky
+/// public wifi hotspot, a brief DNS blip) and normally resolve themselves on
+/// the next attempt, so callers should log them at a lower severity instead
+/// of reporting them as unresolved production errors.
+bool isTransientNetworkError(Object error) {
+  if (error is SocketException ||
+      error is HandshakeException ||
+      error is TimeoutException ||
+      error is HttpException) {
+    return true;
+  }
+
+  final message = error.toString().toLowerCase();
+  const transientMarkers = [
+    'clientexception',
+    'socketexception',
+    'handshakeexception',
+    'connection closed',
+    'connection reset',
+    'connection terminated',
+    'connection refused',
+    'failed host lookup',
+    'network-request-failed',
+    'network error',
+    'operation timed out',
+    'software caused connection abort',
+    "can't assign requested address",
+    'nodename nor servname provided',
+    'no address associated with hostname',
+  ];
+
+  return transientMarkers.any(message.contains);
+}

--- a/lib/screens/auth/state/auth_state.dart
+++ b/lib/screens/auth/state/auth_state.dart
@@ -9,6 +9,7 @@ import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'package:two_eight_two/analytics/analytics.dart';
 import 'package:two_eight_two/config/onboarding_config.dart';
 import 'package:two_eight_two/helpers/device_info_helper.dart';
+import 'package:two_eight_two/helpers/network_error_helper.dart';
 import 'package:two_eight_two/logging/logging.dart';
 import 'package:two_eight_two/models/models.dart';
 import 'package:two_eight_two/repos/repos.dart';
@@ -77,6 +78,10 @@ class AuthState extends ChangeNotifier {
   void _logAuthError(Object error, StackTrace stackTrace) {
     if (error is FirebaseAuthException && _expectedAuthErrorCodes.contains(error.code)) {
       _logger.info('Expected auth error: $error');
+    } else if (isTransientNetworkError(error)) {
+      // A dropped connection mid-request to Firebase Auth — not a code bug,
+      // and the user can just retry, so don't report it as an error.
+      _logger.info('Transient network error during auth request: $error');
     } else {
       _logger.error(error.toString(), stackTrace: stackTrace);
     }

--- a/lib/screens/create_post/widgets/create_post_image_picker.dart
+++ b/lib/screens/create_post/widgets/create_post_image_picker.dart
@@ -97,11 +97,18 @@ class CreatePostImagePicker extends StatelessWidget {
                             ),
                             fadeInDuration: Duration.zero,
                             errorWidget: (context, url, error) {
-                              context.read<Logger>().error(
-                                    'Failed to load photo',
-                                    error: error,
-                                    context: {'imageUrl': url},
-                                  );
+                              if (isTransientNetworkError(error)) {
+                                context.read<Logger>().info('Failed to load photo (transient network error)', context: {
+                                  'imageUrl': url,
+                                  'error': error.toString(),
+                                });
+                              } else {
+                                context.read<Logger>().error(
+                                      'Failed to load photo',
+                                      error: error,
+                                      context: {'imageUrl': url},
+                                    );
+                              }
                               return const Icon(CupertinoIcons.camera_viewfinder);
                             },
                           ),

--- a/lib/screens/edit_profile/edit_profile_screen.dart
+++ b/lib/screens/edit_profile/edit_profile_screen.dart
@@ -150,12 +150,19 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                                   _photoURL!,
                                 ),
                                 onError: (error, stackTrace) {
-                                  context.read<Logger>().error(
-                                        'Failed to load photo',
-                                        error: error,
-                                        stackTrace: stackTrace,
-                                        context: {'imageUrl': _photoURL},
-                                      );
+                                  if (isTransientNetworkError(error)) {
+                                    context.read<Logger>().info('Failed to load photo (transient network error)', context: {
+                                      'imageUrl': _photoURL,
+                                      'error': error.toString(),
+                                    });
+                                  } else {
+                                    context.read<Logger>().error(
+                                          'Failed to load photo',
+                                          error: error,
+                                          stackTrace: stackTrace,
+                                          context: {'imageUrl': _photoURL},
+                                        );
+                                  }
                                 },
                               ),
                             ),

--- a/lib/screens/feed/widgets/post_image_carousel.dart
+++ b/lib/screens/feed/widgets/post_image_carousel.dart
@@ -5,6 +5,7 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:pinch_zoom_release_unzoom/pinch_zoom_release_unzoom.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
+import 'package:two_eight_two/helpers/helpers.dart';
 import 'package:two_eight_two/logging/logging.dart';
 import 'package:two_eight_two/models/models.dart';
 
@@ -74,11 +75,18 @@ class _PostImagesCarouselState extends State<PostImagesCarousel> {
                         ),
                         fadeInDuration: Duration.zero,
                         errorWidget: (context, url, error) {
-                          context.read<Logger>().error(
-                            'Failed to load photo',
-                            error: error,
-                            context: {'imageUrl': url},
-                          );
+                          if (isTransientNetworkError(error)) {
+                            context.read<Logger>().info('Failed to load photo (transient network error)', context: {
+                              'imageUrl': url,
+                              'error': error.toString(),
+                            });
+                          } else {
+                            context.read<Logger>().error(
+                              'Failed to load photo',
+                              error: error,
+                              context: {'imageUrl': url},
+                            );
+                          }
                           return Center(
                             child: Icon(
                               PhosphorIconsRegular.warning,

--- a/lib/screens/munro/state/weather_state.dart
+++ b/lib/screens/munro/state/weather_state.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:two_eight_two/config/app_config.dart';
+import 'package:two_eight_two/helpers/helpers.dart';
 import 'package:two_eight_two/logging/logging.dart';
 import 'package:two_eight_two/models/models.dart';
 import 'package:two_eight_two/repos/repos.dart';
@@ -44,7 +45,14 @@ class WeatherState extends ChangeNotifier {
         code: error.toString(),
         message: "There was an error fetching the weather data.",
       );
-      _logger.error(error.toString(), stackTrace: stackTrace);
+      if (isTransientNetworkError(error)) {
+        // A dropped connection or DNS blip fetching the forecast — the user
+        // sees the same "couldn't load weather" state and can retry; this
+        // isn't a code bug, so don't report it as one.
+        _logger.info('Failed to fetch weather (transient network error): $error');
+      } else {
+        _logger.error(error.toString(), stackTrace: stackTrace);
+      }
       notifyListeners();
     }
   }

--- a/lib/widgets/app_cached_image.dart
+++ b/lib/widgets/app_cached_image.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:provider/provider.dart';
 import 'package:two_eight_two/extensions/extensions.dart';
+import 'package:two_eight_two/helpers/helpers.dart';
 import 'package:two_eight_two/logging/logging.dart';
 
 class AppCachedImage extends StatelessWidget {
@@ -36,11 +37,18 @@ class AppCachedImage extends StatelessWidget {
         fit: BoxFit.cover,
       ),
       errorWidget: (context, url, error) {
-        context.read<Logger>().error(
-              'Failed to load photo',
-              error: error,
-              context: {'imageUrl': url},
-            );
+        if (isTransientNetworkError(error)) {
+          context.read<Logger>().info('Failed to load photo (transient network error)', context: {
+            'imageUrl': url,
+            'error': error.toString(),
+          });
+        } else {
+          context.read<Logger>().error(
+                'Failed to load photo',
+                error: error,
+                context: {'imageUrl': url},
+              );
+        }
         return Center(
           child: Icon(
             PhosphorIconsRegular.warning,

--- a/lib/widgets/circle_profile_piucture.dart
+++ b/lib/widgets/circle_profile_piucture.dart
@@ -1,6 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:two_eight_two/helpers/helpers.dart';
 import 'package:two_eight_two/logging/logging.dart';
 
 import '../screens/profile/screens/screens.dart';
@@ -41,12 +42,19 @@ class CircularProfilePicture extends StatelessWidget {
                     profilePictureURL!,
                   ),
                   onError: (error, stackTrace) {
-                    context.read<Logger>().error(
-                          'Failed to load photo',
-                          error: error,
-                          stackTrace: stackTrace,
-                          context: {'imageUrl': profilePictureURL},
-                        );
+                    if (isTransientNetworkError(error)) {
+                      context.read<Logger>().info('Failed to load photo (transient network error)', context: {
+                        'imageUrl': profilePictureURL,
+                        'error': error.toString(),
+                      });
+                    } else {
+                      context.read<Logger>().error(
+                            'Failed to load photo',
+                            error: error,
+                            stackTrace: stackTrace,
+                            context: {'imageUrl': profilePictureURL},
+                          );
+                    }
                   },
                 ),
         ),

--- a/lib/widgets/full_screen_photos/full_screen_photo_view.dart
+++ b/lib/widgets/full_screen_photos/full_screen_photo_view.dart
@@ -4,6 +4,7 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:photo_view/photo_view_gallery.dart';
 import 'package:provider/provider.dart';
+import 'package:two_eight_two/helpers/helpers.dart';
 import 'package:two_eight_two/logging/logging.dart';
 import 'package:two_eight_two/models/models.dart';
 import 'package:two_eight_two/repos/repos.dart';
@@ -104,12 +105,19 @@ class _FullScreenPhotoViewerState extends State<FullScreenPhotoViewer> {
                 minScale: PhotoViewComputedScale.contained,
                 maxScale: PhotoViewComputedScale.covered * 2,
                 errorBuilder: (context, error, stackTrace) {
-                  context.read<Logger>().error(
-                    'Failed to load photo',
-                    error: error,
-                    stackTrace: stackTrace,
-                    context: {'imageUrl': photos[index].imageUrl},
-                  );
+                  if (isTransientNetworkError(error)) {
+                    context.read<Logger>().info('Failed to load photo (transient network error)', context: {
+                      'imageUrl': photos[index].imageUrl,
+                      'error': error.toString(),
+                    });
+                  } else {
+                    context.read<Logger>().error(
+                      'Failed to load photo',
+                      error: error,
+                      stackTrace: stackTrace,
+                      context: {'imageUrl': photos[index].imageUrl},
+                    );
+                  }
                   return const Center(
                     child: Icon(
                       PhosphorIconsRegular.warning,

--- a/test/helpers/network_error_helper_test.dart
+++ b/test/helpers/network_error_helper_test.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:two_eight_two/helpers/network_error_helper.dart';
+
+void main() {
+  group('isTransientNetworkError', () {
+    test('returns true for SocketException', () {
+      expect(isTransientNetworkError(const SocketException('Failed host lookup')), isTrue);
+    });
+
+    test('returns true for HandshakeException', () {
+      expect(isTransientNetworkError(const HandshakeException('Connection terminated during handshake')), isTrue);
+    });
+
+    test('returns true for TimeoutException', () {
+      expect(isTransientNetworkError(TimeoutException('timed out')), isTrue);
+    });
+
+    test('returns true for a ClientException-style message', () {
+      expect(
+        isTransientNetworkError(
+          Exception(
+            "ClientException with SocketException: Failed host lookup: 'bzzdszqqstspbzyclwxh.supabase.co'",
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns true for a firebase_auth network-request-failed message', () {
+      expect(
+        isTransientNetworkError(
+          Exception('[firebase_auth/unknown] An internal error has occurred. [ connection closed'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns true for an OSError-style DNS failure message', () {
+      expect(
+        isTransientNetworkError(
+          Exception('OSError: OS Error: nodename nor servname provided, or not known, errno = 8'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false for an unrelated application error', () {
+      expect(isTransientNetworkError(StateError('Image compression failed (returned null).')), isFalse);
+    });
+
+    test('returns false for a genuine PostgrestException payload error', () {
+      expect(
+        isTransientNetworkError(
+          Exception('PostgrestException(message: invalid input syntax for type uuid: "", code: 22P02)'),
+        ),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Problem
13 of the unresolved Prod issues share the same root cause: a dropped connection, DNS blip, or TLS handshake failure while loading an image or fetching the weather forecast, unconditionally logged via `Logger.error()` regardless of whether it was transient. `Logger.error()` reports to Sentry, so a routine connectivity hiccup that `CachedNetworkImage` (or the next pull-to-refresh) would silently recover from got recorded as an unresolved production error every time.

Notably **282-APP-MK has 1158 lifetime occurrences** — by far the highest-volume issue in the project — caused by exactly this pattern (a Firebase Storage image download hitting a DNS failure).

- https://alastair-mcneill.sentry.io/issues/282-APP-MK (1158 occurrences / 2 users)
- https://alastair-mcneill.sentry.io/issues/282-APP-H0 (103 occurrences / 12 users)
- https://alastair-mcneill.sentry.io/issues/282-APP-GX (22 occurrences / 7 users)
- https://alastair-mcneill.sentry.io/issues/282-APP-WZ (30 occurrences / 1 user)
- https://alastair-mcneill.sentry.io/issues/282-APP-ZY, 282-APP-V0, 282-APP-10J, 282-APP-Y7, 282-APP-HM, 282-APP-10N, 282-APP-ZK, 282-APP-PQ, 282-APP-WT (lower volume, same signature)

Confirmed via event context/stack traces: WT and MK both carry the `imageUrl` breadcrumb from `AppCachedImage`'s error widget; the auth issues show up via `AuthState._logAuthError`; PQ/MK/WT are all DNS/connection failures fetching `api.openweathermap.org` or Supabase/Firebase Storage image URLs.

## Fix
Added `lib/helpers/network_error_helper.dart`: `isTransientNetworkError()` classifies `SocketException`/`HandshakeException`/`TimeoutException` and common transient message patterns (connection closed/reset, failed host lookup, network-request-failed, etc.) separately from genuine bugs.

Applied it at every "Failed to load photo" logging call site (`AppCachedImage`, `CircularProfilePicture`, `PostImagesCarousel`, `CreatePostImagePicker`, `FullScreenPhotoViewer`, `EditProfileScreen`), `WeatherState.getWeather`, and `AuthState._logAuthError` — transient network errors now log as `info` (still visible as breadcrumb context on other events), genuine failures are still reported as errors exactly as before.

## Testing
No test harness available in this sandbox (no `flutter`/`dart` binary). Added `test/helpers/network_error_helper_test.dart` covering the classifier against real error messages pulled from the affected Sentry events, as a substitute for running the suite myself.

Fixes 282-APP-GX, 282-APP-ZY, 282-APP-V0, 282-APP-10J, 282-APP-Y7, 282-APP-H0, 282-APP-HM, 282-APP-10N, 282-APP-ZK, 282-APP-PQ, 282-APP-MK, 282-APP-WT, 282-APP-WZ

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Af2bNn2xoVHU7Ym6tvHWmT)_