### PR TITLE
Fix: recover from FCM TOO_MANY_REGISTRATIONS instead of failing push setup (282-APP-ZR)

### DIFF
--- a/lib/repos/push_notifications_repository.dart
+++ b/lib/repos/push_notifications_repository.dart
@@ -26,7 +26,20 @@ class PushNotificationRepository {
       final apnsReady = await _ensureApnsToken();
       if (!apnsReady) return null;
     }
-    return _messaging.getToken();
+    try {
+      return await _messaging.getToken();
+    } catch (e) {
+      // On Android, a device can accumulate too many stale FCM registrations
+      // for its Instance ID, and every getToken() call fails with
+      // TOO_MANY_REGISTRATIONS until it's cleared. Deleting the local
+      // Instance ID and requesting a fresh token resolves it — see
+      // https://github.com/firebase/firebase-android-sdk/issues/2438
+      if (e.toString().contains('TOO_MANY_REGISTRATIONS')) {
+        await deleteToken();
+        return await _messaging.getToken();
+      }
+      rethrow;
+    }
   }
 
   Future<void> deleteToken() async {


### PR DESCRIPTION
## Problem
https://alastair-mcneill.sentry.io/issues/282-APP-ZR (9 occurrences / 9 users)

```
FirebaseException: [firebase_messaging/unknown] java.io.IOException: ... TOO_MANY_REGISTRATIONS
```

This is a known Android/FCM condition: a device can accumulate too many stale FCM registrations for its Instance ID, after which every `getToken()` call fails until that Instance ID is cleared (see [firebase-android-sdk#2438](https://github.com/firebase/firebase-android-sdk/issues/2438)). `PushNotificationRepository` already has a `deleteToken()` method for exactly this kind of recovery, but nothing called it — `syncTokenIfNeeded()`/`enablePush()` just failed and reported an unresolved production error every time a device hit this state.

## Fix
`getToken()` now catches `TOO_MANY_REGISTRATIONS` specifically, deletes the stale token, and retries once before giving up. Other `getToken()` failures are unaffected — still rethrown and logged exactly as before.

## Testing
No test harness available in this sandbox (no `flutter`/`dart` binary), and `PushNotificationRepository` wraps the `FirebaseMessaging` singleton directly with no seam to mock in a unit test (consistent with the rest of this repository class, which has no existing tests either).

Fixes 282-APP-ZR
https://alastair-mcneill.sentry.io/issues/282-APP-ZR

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Af2bNn2xoVHU7Ym6tvHWmT)_