### PR TITLE
Fix null-check crash and retry transient network/backend errors (282-APP-112, QR, 110, 107, ZZ, 102, WR)

### DIFF
--- a/lib/helpers/helpers.dart
+++ b/lib/helpers/helpers.dart
@@ -2,3 +2,4 @@ export 'device_info_helper.dart';
 export 'image_helper.dart';
 export 'image_picker_helper.dart';
 export 'munro_marker_icon_helper.dart';
+export 'network_resilience_helper.dart';

--- a/lib/helpers/network_resilience_helper.dart
+++ b/lib/helpers/network_resilience_helper.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// A dropped connection, DNS blip, or backend gateway/statement timeout that
+/// a retry (or the next pull-to-refresh) would silently recover from — as
+/// opposed to a genuine bug or a permanent failure.
+bool isTransientError(Object error) {
+  if (error is TimeoutException) return true;
+
+  if (error is PostgrestException) {
+    const transientCodes = {'504', '57014'};
+    if (transientCodes.contains(error.code)) return true;
+  }
+
+  final message = error.toString().toLowerCase();
+  const transientMarkers = [
+    'socketexception',
+    'clientexception',
+    'handshakeexception',
+    'connection closed',
+    'connection reset',
+    'connection terminated',
+    'connection refused',
+    'operation timed out',
+    'gateway timeout',
+    'statement timeout',
+    "can't assign requested address",
+    'failed host lookup',
+    'software caused connection abort',
+    'network-request-failed',
+  ];
+  return transientMarkers.any(message.contains);
+}
+
+/// Retries [action] with a short linear backoff when it fails with a
+/// transient error; a genuine error (a real API rejection, a programming
+/// error) is rethrown immediately on the first attempt.
+Future<T> withTransientRetry<T>(
+  Future<T> Function() action, {
+  int maxAttempts = 3,
+  Duration delay = const Duration(milliseconds: 500),
+}) async {
+  for (var attempt = 1; ; attempt++) {
+    try {
+      return await action();
+    } catch (error) {
+      if (attempt >= maxAttempts || !isTransientError(error)) rethrow;
+      await Future.delayed(delay * attempt);
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ import 'package:two_eight_two/app.dart';
 import 'package:two_eight_two/app_providers.dart';
 import 'package:two_eight_two/config/app_config.dart';
 import 'package:two_eight_two/config/onboarding_config.dart';
+import 'package:two_eight_two/helpers/helpers.dart';
 import 'package:two_eight_two/push/push.dart';
 import 'package:two_eight_two/support/theme.dart';
 import 'package:two_eight_two/logging/logging.dart';
@@ -40,7 +41,12 @@ main() async {
   await Supabase.initialize(
     url: config.supabaseUrl,
     anonKey: config.supabaseAnonKey,
-    accessToken: () async => FirebaseAuth.instance.currentUser?.getIdToken(false),
+    // Called before every Supabase request; a transient network hiccup
+    // refreshing the Firebase ID token would otherwise fail that request
+    // outright with an uncaught FirebaseAuthException.
+    accessToken: () => withTransientRetry(
+      () async => FirebaseAuth.instance.currentUser?.getIdToken(false),
+    ),
   );
 
   await FirebaseAuth.instance.currentUser?.getIdToken(true);

--- a/lib/repos/likes_repository.dart
+++ b/lib/repos/likes_repository.dart
@@ -8,7 +8,14 @@ class LikesRepository {
   SupabaseQueryBuilder get _view => _db.from('vu_likes');
 
   Future create({required Like like}) async {
-    await _table.insert(like.toJSON());
+    try {
+      await _table.insert(like.toJSON());
+    } on PostgrestException catch (error) {
+      // Unique constraint on (userId, postId) — a double-tap or a retried
+      // request already recorded this like, so treat it as a no-op.
+      if (error.code == '23505') return;
+      rethrow;
+    }
   }
 
   Future delete({

--- a/lib/repos/munro_repository.dart
+++ b/lib/repos/munro_repository.dart
@@ -1,4 +1,5 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:two_eight_two/helpers/helpers.dart';
 import 'package:two_eight_two/models/models.dart';
 
 class MunroRepository {
@@ -8,7 +9,7 @@ class MunroRepository {
   SupabaseQueryBuilder get _view => _db.from('vu_munros');
 
   Future<List<Munro>> getMunroData() async {
-    final response = await _view.select();
+    final response = await withTransientRetry(() => _view.select());
 
     return response.map((item) => Munro.fromJSON(item)).toList();
   }

--- a/lib/repos/posts_repository.dart
+++ b/lib/repos/posts_repository.dart
@@ -1,4 +1,5 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:two_eight_two/helpers/helpers.dart';
 import 'package:two_eight_two/models/models.dart';
 
 class PostsRepository {
@@ -53,15 +54,17 @@ class PostsRepository {
     required List<String> excludedAuthorIds,
     Post? lastPost,
   }) async {
-    final List<dynamic> response = await _db.rpc(
-      'get_friends_feed',
-      params: {
-        'p_limit': 10,
-        'p_before_date_time': lastPost?.dateTimeCreated.toUtc().toIso8601String(),
-        'p_before_id': lastPost?.uid,
-        'p_excluded_author_ids': excludedAuthorIds,
-      },
-    ).timeout(Duration(seconds: 30));
+    final List<dynamic> response = await withTransientRetry(
+      () => _db.rpc(
+        'get_friends_feed',
+        params: {
+          'p_limit': 10,
+          'p_before_date_time': lastPost?.dateTimeCreated.toUtc().toIso8601String(),
+          'p_before_id': lastPost?.uid,
+          'p_excluded_author_ids': excludedAuthorIds,
+        },
+      ).timeout(Duration(seconds: 30)),
+    );
 
     return response.map((doc) => Post.fromJSON(doc as Map<String, dynamic>)).toList();
   }
@@ -71,15 +74,17 @@ class PostsRepository {
     required List<String> excludedAuthorIds,
     Post? lastPost,
   }) async {
-    final List<dynamic> response = await _db.rpc(
-      'get_global_feed',
-      params: {
-        'p_limit': 10,
-        'p_before_date_time': lastPost?.dateTimeCreated.toUtc().toIso8601String(),
-        'p_before_id': lastPost?.uid,
-        'p_excluded_author_ids': excludedAuthorIds,
-      },
-    ).timeout(Duration(seconds: 30));
+    final List<dynamic> response = await withTransientRetry(
+      () => _db.rpc(
+        'get_global_feed',
+        params: {
+          'p_limit': 10,
+          'p_before_date_time': lastPost?.dateTimeCreated.toUtc().toIso8601String(),
+          'p_before_id': lastPost?.uid,
+          'p_excluded_author_ids': excludedAuthorIds,
+        },
+      ).timeout(Duration(seconds: 30)),
+    );
 
     return response.map((doc) => Post.fromJSON(doc as Map<String, dynamic>)).toList();
   }

--- a/lib/repos/storage_repository.dart
+++ b/lib/repos/storage_repository.dart
@@ -70,10 +70,14 @@ class StorageRepository {
     }
   }
 
+  static final _backendGatewayErrorPattern = RegExp(r'unexpected 5\d\d code from backend');
+
   bool _isRetryableUploadError(Object error) {
     if (error is FirebaseException && error.code == 'timeout') return true;
 
     final message = error.toString().toLowerCase();
+    if (_backendGatewayErrorPattern.hasMatch(message)) return true;
+
     const transientMarkers = [
       'socketexception',
       'clientexception',

--- a/lib/screens/feed/widgets/post_image_carousel.dart
+++ b/lib/screens/feed/widgets/post_image_carousel.dart
@@ -53,6 +53,9 @@ class _PostImagesCarouselState extends State<PostImagesCarousel> {
                     Future.delayed(
                       PinchZoomReleaseUnzoomWidget.defaultResetDuration,
                       () {
+                        // The widget can be disposed (e.g. carousel scrolled away,
+                        // post removed) before this delayed callback fires.
+                        if (!mounted) return;
                         setState(() => isZooming = false);
                         PinchZoomNotification(isZooming: false).dispatch(context);
                       },

--- a/test/helpers/network_resilience_helper_test.dart
+++ b/test/helpers/network_resilience_helper_test.dart
@@ -1,0 +1,111 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:two_eight_two/helpers/helpers.dart';
+
+void main() {
+  group('isTransientError', () {
+    test('treats a TimeoutException as transient', () {
+      expect(isTransientError(TimeoutException('after 30s')), isTrue);
+    });
+
+    test('treats a Postgrest gateway timeout (504) as transient', () {
+      expect(
+        isTransientError(PostgrestException(message: '', code: '504', details: 'Gateway Timeout')),
+        isTrue,
+      );
+    });
+
+    test('treats a Postgrest statement timeout (57014) as transient', () {
+      expect(
+        isTransientError(
+          PostgrestException(
+            message: 'canceling statement due to statement timeout',
+            code: '57014',
+            details: 'Internal Server Error',
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('treats a dropped connection as transient', () {
+      expect(
+        isTransientError(Exception('ClientException: Connection closed while receiving data')),
+        isTrue,
+      );
+    });
+
+    test('treats a Firebase network-request-failed error as transient', () {
+      expect(isTransientError(Exception('[firebase_auth/network-request-failed] A network error occurred.')), isTrue);
+    });
+
+    test('does not treat a genuine Postgrest rejection as transient', () {
+      expect(
+        isTransientError(
+          PostgrestException(
+            message: 'duplicate key value violates unique constraint',
+            code: '23505',
+            details: 'Conflict',
+          ),
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not treat an unrelated error as transient', () {
+      expect(isTransientError(StateError('bad state')), isFalse);
+    });
+  });
+
+  group('withTransientRetry', () {
+    test('returns the result on first success without retrying', () async {
+      var calls = 0;
+      final result = await withTransientRetry(() async {
+        calls++;
+        return 'ok';
+      }, delay: Duration.zero);
+
+      expect(result, 'ok');
+      expect(calls, 1);
+    });
+
+    test('retries a transient error and eventually succeeds', () async {
+      var calls = 0;
+      final result = await withTransientRetry(() async {
+        calls++;
+        if (calls < 3) throw TimeoutException('boom');
+        return 'ok';
+      }, delay: Duration.zero);
+
+      expect(result, 'ok');
+      expect(calls, 3);
+    });
+
+    test('rethrows immediately on a non-transient error without retrying', () async {
+      var calls = 0;
+      expect(
+        () => withTransientRetry(() async {
+          calls++;
+          throw StateError('nope');
+        }, delay: Duration.zero),
+        throwsA(isA<StateError>()),
+      );
+      await Future.delayed(Duration.zero);
+      expect(calls, 1);
+    });
+
+    test('rethrows once maxAttempts is exhausted', () async {
+      var calls = 0;
+      await expectLater(
+        () => withTransientRetry(() async {
+          calls++;
+          throw TimeoutException('boom');
+        }, maxAttempts: 2, delay: Duration.zero),
+        throwsA(isA<TimeoutException>()),
+      );
+      expect(calls, 2);
+    });
+  });
+}


### PR DESCRIPTION
## Problem
Seven unresolved Prod issues, two distinct root causes:

- **282-APP-112** (https://alastair-mcneill.sentry.io/issues/282-APP-112): `PostImagesCarousel`'s pinch-zoom-reset `Future.delayed` callback called `setState()` after the widget was already disposed, hitting Flutter's null-check on `State._element` and crashing with `TypeError: Null check operator used on a null value`.
- **282-APP-QR** (https://alastair-mcneill.sentry.io/issues/282-APP-QR, 84 occurrences / 10 users — the highest-volume open issue), **282-APP-110** (https://alastair-mcneill.sentry.io/issues/282-APP-110), **282-APP-107** (https://alastair-mcneill.sentry.io/issues/282-APP-107): `PostsRepository.getFriendsFeed`/`getGlobalFeed` had no retry, so a Postgrest gateway/statement timeout (`504` / `57014`) or the existing 30s client timeout failed the request outright. 282-APP-QR's grouping also included 3 events of a genuine bug: `LikesRepository.create()` had no guard against the `(userId, postId)` unique constraint, so a double-tap or retried request crashed with a `23505` conflict instead of being a no-op.
- **282-APP-ZZ** (https://alastair-mcneill.sentry.io/issues/282-APP-ZZ): `MunroRepository.getMunroData()` (`vu_munros`) had no retry for a dropped connection.
- **282-APP-102** (https://alastair-mcneill.sentry.io/issues/282-APP-102): `StorageRepository` already retried timeouts and common transient-network messages (from a prior fix), but not a clean `"Unexpected 500 code from backend"` Firebase Storage response.
- **282-APP-WR** (https://alastair-mcneill.sentry.io/issues/282-APP-WR): the `accessToken` callback passed to `Supabase.initialize()` calls `FirebaseAuth`'s `getIdToken()` before every request; a transient network hiccup there failed the underlying Postgrest call with an uncaught `FirebaseAuthException`.

## Fix
- `post_image_carousel.dart`: guard the delayed `setState` with `mounted`.
- Added `lib/helpers/network_resilience_helper.dart`: `isTransientError()` classifies socket/client/handshake exceptions, `TimeoutException`, and Postgrest `504`/`57014` responses as transient; `withTransientRetry()` retries such failures with linear backoff and rethrows anything else (or a still-failing transient error) immediately.
- Applied it to `PostsRepository.getFriendsFeed`/`getGlobalFeed`, `MunroRepository.getMunroData`, and the Supabase `accessToken` callback in `main.dart`.
- `LikesRepository.create()` now swallows a `23505` conflict as a no-op.
- `StorageRepository._isRetryableUploadError` now also matches `"unexpected 5xx code from backend"`.

## Not fixed here
- **282-APP-10Q** / **282-APP-10F** (`cloud_firestore` permission-denied): these stack traces are from a Firestore-backed user/notifications code path (`auth_service.dart`, `user_database.dart`, `notifications_database.dart`) that no longer exists in this codebase — both entities are now Supabase-backed (`UserRepository`, `NotificationsRepository`). There's no current code to change; noted directly on the Sentry issues instead.
- **282-APP-10K** (native Android `ArrayIndexOutOfBoundsException` tearing down the Flutter engine on activity destroy) and the three generic **"App Hanging"** issues (**282-APP-10A**, **Y2**, **XV**) have no actionable stack frame in app code — left unresolved for manual triage.

## Testing
No `flutter`/`dart` binary available in this sandbox. Added `test/helpers/network_resilience_helper_test.dart` covering the classifier and retry/no-retry/give-up paths, as a substitute for running the suite myself.

Fixes 282-APP-112, 282-APP-QR, 282-APP-110, 282-APP-107, 282-APP-ZZ, 282-APP-102, 282-APP-WR

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FVFxWttFg8Kuoh9Y4aDHEh)_