### PR TITLE
Fix: don't report transient network errors as fatal (Sentry 282-APP-113)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ import 'package:two_eight_two/app.dart';
 import 'package:two_eight_two/app_providers.dart';
 import 'package:two_eight_two/config/app_config.dart';
 import 'package:two_eight_two/config/onboarding_config.dart';
+import 'package:two_eight_two/helpers/helpers.dart';
 import 'package:two_eight_two/push/push.dart';
 import 'package:two_eight_two/support/theme.dart';
 import 'package:two_eight_two/logging/logging.dart';
@@ -47,7 +48,17 @@ main() async {
 
   final logger = SentryLogger();
   FlutterError.onError = (details) {
-    logger.fatal(details.exception, stackTrace: details.stack);
+    // Framework-level errors can surface transient network failures (e.g. an
+    // image fetch failing mid-load while the app is backgrounded) — treat
+    // those the same as everywhere else instead of reporting them as fatal.
+    if (isTransientNetworkError(details.exception)) {
+      logger.info(
+        'Flutter error (transient network error): ${details.exceptionAsString()}',
+        context: {'error': details.exception.toString()},
+      );
+    } else {
+      logger.fatal(details.exception, stackTrace: details.stack);
+    }
   };
 
   FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);


### PR DESCRIPTION
## Problem

Sentry issue [282-APP-113](https://alastair-mcneill.sentry.io/issues/282-APP-113): `OSError: OS Error: Connection refused, errno = 111`, reported as a fatal production error.

The event shows a `ClientException`/`SocketException` while fetching a munro hero image (`.../storage/v1/object/public/munros/52-beinn-dearg.webp`) from Supabase Storage, with the app backgrounded (`in_foreground: false`, `current_lifecycle_state: paused`) at the time — i.e. a routine connectivity blip, not an application bug.

## Root cause

`lib/main.dart` sets a global `FlutterError.onError` handler that logs **every** Flutter framework-level error via `logger.fatal(...)`, unconditionally. This bypasses the `isTransientNetworkError` filtering (`lib/helpers/network_helper.dart`) that the rest of the codebase already applies to network-related failures (see `AuthState._logAuthError`, `Logger.logPossibleNetworkError`, `AppCachedImage`'s error widget) — so a transient network error that surfaces through the Flutter error zone (e.g. an image load failing mid-fetch while backgrounded) still gets reported to Sentry as a fatal issue.

## Fix

`FlutterError.onError` now checks `isTransientNetworkError` on the exception before deciding how to log it:
- Transient network errors (`SocketException`, `OSError`, `ClientException`, timeouts, etc.) are logged at `info` level, consistent with how the same error classes are already handled elsewhere.
- Everything else still goes through `logger.fatal` as before, so genuine crashes are unaffected.

## Testing

No `flutter`/`dart` toolchain is available in this environment, so I wasn't able to run `flutter analyze` — please verify in CI/locally.

Fixes 282-APP-113 (will be marked resolved in the next release).
https://alastair-mcneill.sentry.io/issues/282-APP-113

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLhapRDqNbzAy6EuJiv4zn)_