### PR TITLE
Fix App Hang in Explore search focus handling (Sentry 282-APP-10A)

### DIFF
--- a/lib/screens/explore/explore_tab.dart
+++ b/lib/screens/explore/explore_tab.dart
@@ -86,7 +86,12 @@ class _ExploreTabState extends State<ExploreTab> {
                 _hasLoggedPanelOpen = false;
                 _isMunroListViewVisible = false;
                 borderRadius = const BorderRadius.vertical(top: Radius.circular(24));
-                _searchFocusNode.unfocus();
+                // onPanelSlide fires on every animation frame while position < 0.8, so
+                // guard against re-issuing resignFirstResponder each frame - repeated
+                // calls raced with keyboard focus changes and hung the main thread.
+                if (_searchFocusNode.hasFocus) {
+                  _searchFocusNode.unfocus();
+                }
               }
             }),
             panelBuilder: (sc) {

--- a/lib/screens/explore/explore_tab.dart
+++ b/lib/screens/explore/explore_tab.dart
@@ -86,9 +86,6 @@ class _ExploreTabState extends State<ExploreTab> {
                 _hasLoggedPanelOpen = false;
                 _isMunroListViewVisible = false;
                 borderRadius = const BorderRadius.vertical(top: Radius.circular(24));
-                // onPanelSlide fires on every animation frame while position < 0.8, so
-                // guard against re-issuing resignFirstResponder each frame - repeated
-                // calls raced with keyboard focus changes and hung the main thread.
                 if (_searchFocusNode.hasFocus) {
                   _searchFocusNode.unfocus();
                 }


### PR DESCRIPTION
## Problem

Sentry issue [282-APP-10A](https://alastair-mcneill.sentry.io/issues/282-APP-10A): **App Hanging for at least 2000 ms**, reported on iOS (iPad11,6, iOS 26.5.2, release `2.0.3+113`). The main thread was blocked inside `-[UIKeyboardTaskQueue lockWhenReadyForMainThread]`, reached via `resignFirstResponder` → `_finishResignFirstResponderFromBecomeFirstResponder` → `UIKeyboardSceneDelegate`'s input-view reload path.

## Root cause

In `ExploreTab`, `SlidingUpPanel.onPanelSlide` fires on **every animation frame** while the panel is sliding. The handler unconditionally called:

```dart
} else if (position < 0.8) {
  ...
  _searchFocusNode.unfocus();
}
```

Since `position < 0.8` is true for most of the panel's travel range, `unfocus()` was invoked dozens of times per open/close gesture, not once. Each call round-trips into the platform's text input plugin (`resignFirstResponder` on iOS). Firing it repeatedly in quick succession — especially while `onSearchTap` calls `_searchFocusNode.requestFocus()` right as the panel starts its open animation — raced with the keyboard's own focus-transition bookkeeping and produced the reported hang in `UIKeyboardTaskQueue`.

## Fix

Guard the call with `_searchFocusNode.hasFocus` so the native unfocus call only happens once (the first frame it actually takes effect), instead of on every subsequent frame while `position < 0.8`:

```dart
if (_searchFocusNode.hasFocus) {
  _searchFocusNode.unfocus();
}
```

This removes the redundant platform-channel churn that was the trigger for the hang, without changing any user-visible behavior.

## Testing

`flutter analyze` / the iOS simulator could not be run in this sandboxed environment (no Flutter SDK available). The change is a single, narrowly-scoped guard around an existing call — reviewed by inspection. Please verify manually by rapidly opening/closing the Explore search panel with the keyboard up.

Fixes 282-APP-10A
https://alastair-mcneill.sentry.io/issues/282-APP-10A


---
_Generated by [Claude Code](https://claude.ai/code/session_01LXqUupiU6fRh5WHcnJDLFi)_