### PR TITLE
Fix Sentry 282-APP-114 and 282-APP-10K: review null-cast crash and age-signals detach crash

### DIFF
--- a/android/app/src/main/kotlin/com/example/two_eight_two/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/two_eight_two/MainActivity.kt
@@ -8,8 +8,15 @@ import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 
 class MainActivity : FlutterActivity() {
+    // Guards against Play Services callbacks landing after the engine has
+    // detached (e.g. activity destroyed while the age signals request was
+    // still in flight), which otherwise crashes writing into the
+    // already-torn-down plugin/channel registry.
+    private var isEngineAttached = false
+
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
+        isEngineAttached = true
 
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "com.alastairrmcneill.TwoEightTwo/age_range")
             .setMethodCallHandler { call, result ->
@@ -19,6 +26,11 @@ class MainActivity : FlutterActivity() {
                 }
                 requestAgeSignal(result)
             }
+    }
+
+    override fun cleanUpFlutterEngine(flutterEngine: FlutterEngine) {
+        isEngineAttached = false
+        super.cleanUpFlutterEngine(flutterEngine)
     }
 
     // Bridges to Google Play's Age Signals API so Flutter can check a user's
@@ -32,6 +44,7 @@ class MainActivity : FlutterActivity() {
         ageSignalsManager
             .checkAgeSignals(AgeSignalsRequest.builder().build())
             .addOnSuccessListener { ageSignalsResult ->
+                if (!isEngineAttached) return@addOnSuccessListener
                 val status = ageSignalsResult.userStatus()
                 if (status == null ||
                     status == AgeSignalsVerificationStatus.UNKNOWN ||
@@ -43,6 +56,7 @@ class MainActivity : FlutterActivity() {
                 }
             }
             .addOnFailureListener {
+                if (!isEngineAttached) return@addOnFailureListener
                 result.success(null)
             }
     }

--- a/lib/models/review_model.dart
+++ b/lib/models/review_model.dart
@@ -35,7 +35,7 @@ class Review {
       uid: json[ReviewFields.uid] as String?,
       munroId: json[ReviewFields.munroId] as int,
       authorId: json[ReviewFields.authorId] as String,
-      authorDisplayName: json[ReviewFields.authorDisplayName] as String,
+      authorDisplayName: (json[ReviewFields.authorDisplayName] as String?) ?? '',
       authorProfilePictureURL: json[ReviewFields.authorProfilePictureURL] as String?,
       dateTime: DateTime.parse(json[ReviewFields.dateTime] as String),
       rating: json[ReviewFields.rating] as int,


### PR DESCRIPTION
## Summary

Fixes two unresolved production crashes surfaced in Sentry for project `282-app` (environment: Prod).

### 1. `Review.fromJSON` null cast — [282-APP-114](https://alastair-mcneill.sentry.io/issues/282-APP-114)

```
_Exception: Exception: type 'Null' is not a subtype of type 'String' in type cast
  at CreateReviewState.createReview (create_review_state.dart:57)
  at ReviewsRepository.create (reviews_repository.dart:13)
  at Review.fromJSON (review_model.dart:38)
```

`Review.toJSON()` doesn't send `author_display_name` on insert — it's populated by a DB default/trigger — so the row returned by `.select().single()` can come back with a null `author_display_name`. `Review.fromJSON` force-cast it with `as String`, which threw whenever that happened.

**Fix:** `lib/models/review_model.dart` — cast `authorDisplayName` as nullable and fall back to `''`, matching the null-safe pattern already used for `authorProfilePictureURL`/`uid` in the same method.

### 2. Activity destroy crash — [282-APP-10K](https://alastair-mcneill.sentry.io/issues/282-APP-10K)

```
RuntimeException: Unable to destroy activity {.../MainActivity}
Caused by: ArrayIndexOutOfBoundsException: Array index out of range: 2
  at android.util.SparseArray.valueAt
  at k.c.j
  at m5.f.onDetachedFromEngine
  at T4.h.f
  at T4.d.onDestroy
```

`MainActivity.requestAgeSignal` registers async Play Services listeners (`addOnSuccessListener`/`addOnFailureListener`) against the Age Signals API. If the activity is destroyed while that request is still in flight, the listener can fire after the `FlutterEngine` has begun detaching, calling `MethodChannel.Result.success(...)` into an already-torn-down plugin/channel registry — landing in the `SparseArray` access that throws here.

**Fix:** `android/app/src/main/kotlin/com/example/two_eight_two/MainActivity.kt` — track engine attachment via `configureFlutterEngine`/`cleanUpFlutterEngine` and drop the callback if the engine has already detached by the time it fires.

## Notes

- `flutter analyze` / `flutter test` weren't runnable in this sandbox (no Flutter SDK available); changes are minimal and type-safe — please run CI/local checks before merge.
- Both Sentry issues will be marked "resolved in the next release" once this merges.

Refs: https://alastair-mcneill.sentry.io/issues/282-APP-114, https://alastair-mcneill.sentry.io/issues/282-APP-10K

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1sUBKiybQPFBFQ3ExYLpt)_