### PR TITLE
Fix: don't report transient FCM SERVICE_NOT_AVAILABLE as fatal (282-APP-W5)

### DIFF
--- a/lib/helpers/network_helper.dart
+++ b/lib/helpers/network_helper.dart
@@ -25,6 +25,9 @@ bool isTransientNetworkError(Object error) {
     'failed host lookup',
     'network-request-failed',
     'network error',
+    // FCM's own transient "Google Play services unreachable" signal — retrying
+    // later (e.g. on the next token refresh) resolves it without user action.
+    'service_not_available',
     'operation timed out',
     'software caused connection abort',
     "can't assign requested address",

--- a/lib/push/push_notifications_state.dart
+++ b/lib/push/push_notifications_state.dart
@@ -144,7 +144,7 @@ class PushNotificationState extends ChangeNotifier {
         deviceModel: deviceInfo.deviceModel,
       );
     } catch (e, st) {
-      _logger.error('Sync FCM token failed', error: e, stackTrace: st);
+      _logger.logPossibleNetworkError('Sync FCM token failed', e, stackTrace: st);
     }
   }
 


### PR DESCRIPTION
## Problem
https://alastair-mcneill.sentry.io/issues/282-APP-W5 (5 occurrences / 1 user, first seen 2026-04-01, still occurring as recently as 2026-08-12)

```
FirebaseException: [firebase_messaging/unknown] java.io.IOException: java.util.concurrent.ExecutionException: java.io.IOException: SERVICE_NOT_AVAILABLE
    at PushNotificationState.syncTokenIfNeeded (push_notifications_state.dart:129)
    at MethodChannelFirebaseMessaging.getToken (method_channel_messaging.dart:248)
```

`SERVICE_NOT_AVAILABLE` is FCM's own transient signal that Google Play services were unreachable when `getToken()` was called (e.g. right after boot, brief connectivity loss) — it resolves itself on the next token refresh and isn't something the app can act on.

`syncTokenIfNeeded()` already catches this, but logged it via `_logger.error(...)`, which unconditionally reports to Sentry as a production error — bypassing the `isTransientNetworkError`/`logPossibleNetworkError` filtering this codebase already uses elsewhere for exactly this class of problem (e.g. `AuthState`, `WeatherState`, and the FlutterError.onError fix in #176 / 282-APP-113).

## Fix
- Added a `service_not_available` marker to `isTransientNetworkError` in `network_helper.dart`.
- Switched the `syncTokenIfNeeded` catch block to `_logger.logPossibleNetworkError(...)`, so this case now logs as an info breadcrumb instead of a Sentry error, consistent with how other transient failures are handled.

## Testing
No `flutter`/`dart` binary available in this sandbox to run `flutter analyze` or the existing push notification tests. The change is a narrow, behavior-preserving swap of one logging call plus a new string marker, consistent with the existing `push_notifications_state_test.dart` coverage (which doesn't assert on this specific log call).

Fixes 282-APP-W5
https://alastair-mcneill.sentry.io/issues/282-APP-W5

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RD9C7ELQD9zdtpjQ84U3KL)_