### PR TITLE
Fix: setState after dispose crash in Google sign-in onboarding (282-APP-115)

### DIFF
--- a/lib/screens/onboarding/screens/onboarding_sign_in_prompt_screen.dart
+++ b/lib/screens/onboarding/screens/onboarding_sign_in_prompt_screen.dart
@@ -188,6 +188,9 @@ class _OnboardingSignInPromptScreenState extends State<OnboardingSignInPromptScr
                     // Google sign-in
                     _OnboardingGoogleButton(
                       onResult: (result) async {
+                        // The Google sign-in flow backgrounds the app (account picker); by the
+                        // time it resolves, this screen may have been unmounted.
+                        if (!mounted) return;
                         setState(() => _errorMessage = null);
                         await _handleAuthResult(result);
                       },


### PR DESCRIPTION
## Problem

[282-APP-115](https://alastair-mcneill.sentry.io/issues/282-APP-115) — `TypeError: Null check operator used on a null value`, fatal, uncaught (`PlatformDispatcher.onError`).

Culprit: `_OnboardingSignInPromptScreenState.build.<fn>` in `onboarding_sign_in_prompt_screen.dart`.

## Root cause

Breadcrumbs on the event show the app going to background and returning to foreground right before the crash — consistent with the Google account picker sheet being shown during `signInWithGoogle()`.

In `_OnboardingGoogleButton`'s `onResult` callback:

```dart
onResult: (result) async {
  setState(() => _errorMessage = null);
  await _handleAuthResult(result);
},
```

`setState()` is called with no `mounted` check, after the async gap caused by the Google sign-in flow (`await context.read<AuthState>().signInWithGoogle(...)` in the child button, then `await onResult(result)`). If the screen was unmounted while the account picker was open (e.g. the user navigated away), `State.setState` throws inside `_element!.markNeedsBuild()` — exactly a "Null check operator used on a null value". Since the button's `onPressed` handler is a fire-and-forget `async` callback, nothing awaits or catches this, so it reaches `PlatformDispatcher.onError` as fatal and crashes the app.

The same file already guards `_handleAuthResult` with `if (!mounted) return;` and guards the Apple sign-in path's post-await `_handleAuthResult` call with `if (mounted) ...` — this `setState` call was the one path missing the guard.

## Fix

Add a `mounted` check before the `setState` call in the Google sign-in `onResult` callback, matching the existing pattern used elsewhere in this file.

## Note on the two Mapbox annotation issues also open in Sentry (282-APP-100, 282-APP-106)

Both are the same `PlatformException: Annotation has not been added on the map` crash already fixed by #166 (`dd57a55`, merged 2026-08-06). Every event on both issues — including the most recent ones from today — comes from app releases 2.0.1+111 through 2.0.3+113, all of which predate that fix; there are zero events from any build after it shipped. No further code change is needed — resolving them directly in Sentry as already-fixed-by-#166 rather than opening a duplicate PR.

Sentry issue: https://alastair-mcneill.sentry.io/issues/282-APP-115


---
_Generated by [Claude Code](https://claude.ai/code/session_013jgAAbywHspPdDrXpUhCsx)_