### PR TITLE
Fix: don't let Supabase access-token refresh failures crash as fatal (282-APP-VH)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,15 +38,32 @@ main() async {
     // Styles are being iterated on in Mapbox Studio; never render a stale cached copy in dev.
     await MapboxMapsOptions.clearData();
   }
+  final logger = SentryLogger();
+
   await Supabase.initialize(
     url: config.supabaseUrl,
     anonKey: config.supabaseAnonKey,
-    accessToken: () async => FirebaseAuth.instance.currentUser?.getIdToken(false),
+    accessToken: () async {
+      try {
+        return await withNetworkRetry(
+          () => FirebaseAuth.instance.currentUser?.getIdToken(false),
+        );
+      } catch (error, stackTrace) {
+        // Falls back to the anon key for this request rather than crashing the
+        // Postgrest/Realtime call that triggered the token refresh — Supabase
+        // will simply retry with a fresh token next time one is needed.
+        logger.logPossibleNetworkError(
+          'Failed to refresh Supabase access token',
+          error,
+          stackTrace: stackTrace,
+        );
+        return null;
+      }
+    },
   );
 
   await FirebaseAuth.instance.currentUser?.getIdToken(true);
 
-  final logger = SentryLogger();
   FlutterError.onError = (details) {
     // Framework-level errors can surface transient network failures (e.g. an
     // image fetch failing mid-load while the app is backgrounded) — treat


### PR DESCRIPTION
## Problem

Sentry issue [282-APP-VH](https://alastair-mcneill.sentry.io/issues/282-APP-VH) — `_Exception: [firebase_auth/network-request-failed] Network error ... has occurred.` — is reported as a fatal, unresolved production error (21 occurrences over ~5 months, most recently 3 days ago).

The stack trace shows the failure originating from Supabase's internal token-refresh path:

```
PostgrestBuilder.then → PostgrestBuilder._execute → BaseClient._sendUnstreamed
→ AuthHttpClient.send → SupabaseClient._getAccessToken → MethodChannelUser.getIdToken
→ FirebaseAuthUserHostApi.getIdToken
```

`main.dart` passes a bare `accessToken` callback to `Supabase.initialize()`:

```dart
accessToken: () async => FirebaseAuth.instance.currentUser?.getIdToken(false),
```

Every other network-touching call site in this codebase (image loads, push token sync, weather, onboarding, posts) routes through `isTransientNetworkError`/`Logger.logPossibleNetworkError` so a routine connectivity blip is logged as an info breadcrumb instead of a fatal Sentry error — but this callback has none of that. When the Firebase token fetch hits a transient network failure, the exception propagates uncaught through Supabase's Postgrest builder into whatever request triggered the refresh, and Sentry's zone-level capture reports it as fatal.

## Fix

Wrap the token fetch in the existing `withNetworkRetry` helper (retries transient failures with backoff) and route any error that still remains through `logPossibleNetworkError`, falling back to `null` (the anon key) for that request rather than letting the exception crash the caller. This matches the pattern already used everywhere else in the app (see #174, #181).

## Testing

- `flutter analyze`/tests not run in this sandbox (no Flutter SDK available) — the change is isolated to `main.dart`'s init glue, which has no existing unit test coverage, and reuses already-tested helpers (`withNetworkRetry`, `logPossibleNetworkError`).

Fixes 282-APP-VH
https://alastair-mcneill.sentry.io/issues/282-APP-VH

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgttdjhKejJDTqomxLvcno)_